### PR TITLE
12 characters default length; special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,24 @@ GOBIN=$(pwd) GOPATH=$(mktemp -d) go get github.com/carlmjohnson/opensesame
 ## Screenshots
 ```shell
 $ opensesame
-OCo6X1Py
+9%cjTE^O@iYx
 
 $ opensesame -h
 Usage of opensesame [opts] [alphabet]:
 
-        Creates a password by randomly selecting characters from its alphabet.
+	Creates a password by randomly selecting characters from its alphabet.
 
-        Alphabet is a space separated list of character classes to use.
-        At least one character in each class will be output.
-        Character classes are either literal sets (like "abc" and "123") or the
-        special names "upper", "lower", "digit", and "default".
+	Alphabet is a space separated list of character classes to use.
+	At least one character in each class will be output.
+	Character classes are either literal sets (like "abc" and "123") or the
+	names "upper", "lower", "digit", "special" and "default". The "special"
+ 	alphabet contains characters like "$" and "&" often required by online
+ 	password guidelines.
 
-        Default alphabet is "upper lower digit".
+	Default alphabet is "upper lower digit special".
 
-  -length int
-        length of password to generate (default 8)
+	-length int
+		length of password to generate (default 12)
 
 $ opensesame --length 4 '123 ABC xyz &%$'
 &Cx3

--- a/opensesame.go
+++ b/opensesame.go
@@ -14,10 +14,12 @@ func main() {
 		upper           = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 		lower           = "abcdefghijklmnopqrstuvwxyz"
 		digit           = "0123456789"
-		defaultAlphabet = "upper lower digit"
+		special         = "~!@#$%^&*()[].?"
+		defaultAlphabet = "upper lower digit special"
 	)
 
-	length := flag.Int("length", 8, "length of password to generate")
+	// https://blog.codinghorror.com/your-password-is-too-damn-short/
+	length := flag.Int("length", 12, "length of password to generate")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, `Usage of %s [opts] [alphabet]:
 
@@ -26,7 +28,9 @@ func main() {
 	Alphabet is a space separated list of character classes to use.
 	At least one character in each class will be output.
 	Character classes are either literal sets (like "abc" and "123") or the
-	special names "upper", "lower", "digit", and "default".
+	names "upper", "lower", "digit", "special" and "default". The "special"
+ 	alphabet contains characters like "$" and "&" often required by online 
+ 	password guidelines.
 
 	Default alphabet is %q.
 
@@ -44,9 +48,9 @@ func main() {
 	alpha = strings.Replace(alpha, "lower", lower, -1)
 	alpha = strings.Replace(alpha, "digits", digit, -1)
 	alpha = strings.Replace(alpha, "digit", digit, -1)
+	alpha = strings.Replace(alpha, "special", special, -1)
 
 	alphas := strings.Split(alpha, " ")
-
 	if pass, err := pass.New(*length, alphas...); err == nil {
 		fmt.Println(pass)
 	} else {


### PR DESCRIPTION
Rationale:

* Many online sites require a special character like `$` or `?` in their policies
* 8 characters is too shrot a password (see https://blog.codinghorror.com/your-password-is-too-damn-short/)